### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled command line

### DIFF
--- a/src/main/java/com/endor/OSCommandServlet.java
+++ b/src/main/java/com/endor/OSCommandServlet.java
@@ -32,7 +32,17 @@ public class OSCommandServlet extends HttpServlet {
         out.println(form);
 
         String command = request.getParameter("command");
-        String find = "find " + command;
-        Runtime.getRuntime().exec(find);
+        if (command == null || !command.matches("^[a-zA-Z0-9_\\-\\.]+$")) {
+            out.println("<p>Invalid command. Only alphanumeric characters, underscores, hyphens, and dots are allowed.</p>");
+        } else {
+            ProcessBuilder processBuilder = new ProcessBuilder("find", command);
+            try {
+                Process process = processBuilder.start();
+                process.waitFor();
+                out.println("<p>Command executed successfully.</p>");
+            } catch (Exception e) {
+                out.println("<p>Error executing command: " + e.getMessage() + "</p>");
+            }
+        }
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Pandante-Central/app-java-demo/security/code-scanning/6](https://github.com/Pandante-Central/app-java-demo/security/code-scanning/6)

To fix the issue, we need to ensure that user input is not directly passed to `Runtime.exec` without validation. The best approach is to avoid constructing shell commands dynamically using user input. Instead:
1. Use a hardcoded command or a whitelist of allowed commands.
2. If dynamic input is necessary, validate the input to ensure it is safe and does not contain malicious content.
3. Use safer alternatives to `Runtime.exec`, such as Java's `ProcessBuilder`, which allows for better control over command execution without invoking a shell.

In this case, we will:
- Validate the `command` parameter to ensure it contains only safe characters (e.g., alphanumeric characters and specific safe symbols like underscores or hyphens).
- Use `ProcessBuilder` to execute the command safely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
